### PR TITLE
fix: palette_overrides config not working

### DIFF
--- a/lua/neofusion/init.lua
+++ b/lua/neofusion/init.lua
@@ -70,7 +70,7 @@ local function get_colors()
   local config = Neofusion.config
 
   for color, hex in pairs(config.palette_overrides) do
-    config[color] = hex
+    palette[color] = hex
   end
 
   local color_groups = {


### PR DESCRIPTION
Last night I was trying to add a bit of Value to some colors because my background was a bit too dark to see them. Found out that anything under `palette_overrides` wasn't being considered. After changing it, my changes started to be reflected on neofusion.